### PR TITLE
Fix infinite loop

### DIFF
--- a/lib/rgeo/active_record/common.rb
+++ b/lib/rgeo/active_record/common.rb
@@ -72,7 +72,7 @@ module RGeo
             col_ = @engine.columns_hash[node_.name.to_s]
             col_ && col_.respond_to?(:spatial?) && col_.spatial?
           ensure
-            @connection.instance_variable_set(:@_getting_columns, false)
+            @connection.remove_instance_variable(:@_getting_columns)
           end
         when ::RGeo::Feature::Instance
           true


### PR DESCRIPTION
For some reason, the original code causes an infinite loop during rake db:rollback.

Removing the @_getting_columns variable instead of just setting it to false fixes that. Unfortunately, I don't really know _why_ that works, so there might be a better way to do this. But this change at least restores rollback functionality.
