### PR TITLE
Fix proc error in default factory

### DIFF
--- a/lib/rgeo/active_record/ar_factory_settings.rb
+++ b/lib/rgeo/active_record/ar_factory_settings.rb
@@ -85,8 +85,8 @@ module RGeo
         column_name_ = column_name_.to_s
         result_ = (@column_factories[table_name_] ||= {})[column_name_] ||
           @factory_generators[table_name_] || ::RGeo::ActiveRecord::DEFAULT_FACTORY_GENERATOR
-        if params_ && !result_.kind_of?(::RGeo::Feature::Factory::Instance)
-          result_ = result_.call(params_)
+        unless result_.kind_of?(::RGeo::Feature::Factory::Instance)
+          result_ = result_.call(params_ || {})
         end
         result_
       end

--- a/rgeo-activerecord.gemspec
+++ b/rgeo-activerecord.gemspec
@@ -37,7 +37,7 @@
   s_.name = 'rgeo-activerecord'
   s_.summary = 'An RGeo module providing spatial extensions to ActiveRecord.'
   s_.description = "RGeo is a geospatial data library for Ruby. RGeo::ActiveRecord is an optional RGeo module providing some spatial extensions to ActiveRecord, as well as common tools used by RGeo-based spatial adapters."
-  s_.version = "#{::File.read('Version').strip}.nonrelease"
+  s_.version = ::File.read('Version').strip
   s_.author = 'Daniel Azuma'
   s_.email = 'dazuma@gmail.com'
   s_.homepage = "http://dazuma.github.com/rgeo-activerecord"


### PR DESCRIPTION
This fixes the error mentioned in https://github.com/dazuma/activerecord-postgis-adapter/issues/63, where the factory is unexpectedly a Proc. Apparently the Proc isn't getting called unless `params_` (why the underscore?) is present, so I've changed the logic a bit here.