### PR TITLE
Fix compatibility with Rails 4/Arel 4.0.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -206,6 +206,7 @@ end
 
 task :test => [:build_ext, :build_other] do
   $:.unshift(::File.expand_path('lib', ::File.dirname(__FILE__)))
+  $:.unshift(::File.expand_path('test', ::File.dirname(__FILE__)))
   if (cases_ = ::ENV['TESTCASE'])
     test_files_ = cases_.split(',').map{ |c_| ::Dir.glob("test/#{c_}.rb") }.flatten
   else

--- a/test/support/fake_record.rb
+++ b/test/support/fake_record.rb
@@ -1,0 +1,124 @@
+# From https://github.com/rails/arel/blob/4-0-stable/test/support/fake_record.rb
+module FakeRecord
+  class Column < Struct.new(:name, :type)
+  end
+
+  class Connection
+    attr_reader :tables
+    attr_accessor :visitor
+
+    def initialize(visitor = nil)
+      @tables = %w{ users photos developers products}
+      @columns = {
+        'users' => [
+          Column.new('id', :integer),
+          Column.new('name', :string),
+          Column.new('bool', :boolean),
+          Column.new('created_at', :date)
+        ],
+        'products' => [
+          Column.new('id', :integer),
+          Column.new('price', :decimal)
+        ]
+      }
+      @columns_hash = {
+        'users' => Hash[@columns['users'].map { |x| [x.name, x] }],
+        'products' => Hash[@columns['products'].map { |x| [x.name, x] }]
+      }
+      @primary_keys = {
+        'users' => 'id',
+        'products' => 'id'
+      }
+      @visitor = visitor
+    end
+
+    def columns_hash table_name
+      @columns_hash[table_name]
+    end
+
+    def primary_key name
+      @primary_keys[name.to_s]
+    end
+
+    def table_exists? name
+      @tables.include? name.to_s
+    end
+
+    def columns name, message = nil
+      @columns[name.to_s]
+    end
+
+    def quote_table_name name
+      "\"#{name.to_s}\""
+    end
+
+    def quote_column_name name
+      "\"#{name.to_s}\""
+    end
+
+    def schema_cache
+      self
+    end
+
+    def quote thing, column = nil
+      if column && column.type == :integer
+        return 'NULL' if thing.nil?
+        return thing.to_i
+      end
+
+      case thing
+      when true
+        "'t'"
+      when false
+        "'f'"
+      when nil
+        'NULL'
+      when Numeric
+        thing
+      else
+        "'#{thing}'"
+      end
+    end
+  end
+
+  class ConnectionPool
+    class Spec < Struct.new(:config)
+    end
+
+    attr_reader :spec, :connection
+
+    def initialize
+      @spec = Spec.new(:adapter => 'america')
+      @connection = Connection.new
+      @connection.visitor = Arel::Visitors::ToSql.new(connection)
+    end
+
+    def with_connection
+      yield connection
+    end
+
+    def table_exists? name
+      connection.tables.include? name.to_s
+    end
+
+    def columns_hash
+      connection.columns_hash
+    end
+
+    def schema_cache
+      connection
+    end
+  end
+
+  class Base
+    attr_accessor :connection_pool
+
+    def initialize
+      @connection_pool = ConnectionPool.new
+    end
+
+    def connection
+      connection_pool.connection
+    end
+  end
+end

--- a/test/tc_basic.rb
+++ b/test/tc_basic.rb
@@ -34,9 +34,7 @@
 ;
 
 
-require 'test/unit'
-require 'rgeo/active_record'
-
+require 'test_helper'
 
 module RGeo
   module ActiveRecord
@@ -102,9 +100,21 @@ module RGeo
           assert_equal({'type' => 'Point', 'coordinates' => [1.0, 2.0]}, p_.as_json)
         end
 
+        def test_arel_visit_SpatialConstantNode
+          visitor = arel_visitor
+          sql = visitor.accept(Arel.spatial('POINT (1.0 2.0)'))
+          assert_equal("ST_WKTToSQL('POINT (1.0 2.0)')", sql)
+        end
 
+        # SpatialNamedFunction is not used in pre-2.1 Arel.
+        if(AREL_VERSION_MAJOR > 2 || (AREL_VERSION_MAJOR == 2 && AREL_VERSION_MINOR >= 1))
+          def test_arel_visit_SpatialNamedFunction
+            visitor = arel_visitor
+            sql = visitor.accept(Arel.spatial('POINT (1.0 2.0)').st_astext)
+            assert_equal("ST_AsText(ST_WKTToSQL('POINT (1.0 2.0)'))", sql)
+          end
+        end
       end
-
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,21 @@
+require 'test/unit'
+require 'rgeo/active_record'
+require 'support/fake_record'
+
+AREL_VERSION_MAJOR, AREL_VERSION_MINOR, AREL_VERSION_PATCH = ::Arel::VERSION.split('.').map { |part| part.to_i }
+Arel::Visitors::PostgreSQL.send(:include, ::RGeo::ActiveRecord::SpatialToSql)
+Arel::Table.engine = Arel::Sql::Engine.new(FakeRecord::Base.new)
+
+def arel_visitor
+  # The argument for constructing visitor objects depends on the version of
+  # Arel.
+  if(AREL_VERSION_MAJOR <= 2)
+    if(AREL_VERSION_MAJOR == 2 && AREL_VERSION_MINOR == 0)
+      Arel::Visitors::PostgreSQL.new(Arel::Table.engine)
+    else
+      Arel::Visitors::PostgreSQL.new(Arel::Table.engine.connection_pool)
+    end
+  else
+    Arel::Visitors::PostgreSQL.new(Arel::Table.engine.connection)
+  end
+end


### PR DESCRIPTION
I ran into some issues with the activerecord-postgis-adapter under Rails 4. The problem seems to have cropped up since the Arel 4.0.1 release, since the method signature of the Arel stuff changed in that release:
https://github.com/rails/arel/commit/68a95542e1a7a79d9777223fbffd2b982fed0268

There weren't any failing tests in this rgeo-activerecord project, but you can see that this issue was caught by the activerecord-postgis-adapter test suite, since the Rails 4 tests started to fail on [newer pull requests](https://travis-ci.org/dazuma/activerecord-postgis-adapter/jobs/18669917) (basically on any tests run since Arel 4.0.1 was released).

The fix is relatively straightforward, the visitor methods just need to take in an extra, optional argument (attribute). I've made the handling of this extra argument optional, so it continues to work in older Arel versions. I also added some basic tests surrounding this Arel functionality using a FakeRecord class taken from how Arel performs its own similar visitor tests.
