### PR TITLE
Use the cache_attributes() method

### DIFF
--- a/lib/rgeo/active_record/common_adapter_elements.rb
+++ b/lib/rgeo/active_record/common_adapter_elements.rb
@@ -127,8 +127,7 @@ module RGeo
 
 
     # Tell ActiveRecord to cache spatial attribute values so they don't get re-parsed on every access.
-
-    ::ActiveRecord::Base.attribute_types_cached_by_default << :spatial
+    ::ActiveRecord::Base.cache_attributes(:spatial)
 
     # :startdoc:
   end


### PR DESCRIPTION
This uses the proper ActiveRecord method to declare cached attributes.

It is deprecated in Rails 4.2.0 so this method will now just produce a warning instead of failing since the `attribute_types_cached_by_default` has been removed.
