### PR TITLE
Dump schema using new style hash

### DIFF
--- a/lib/rgeo/active_record/common_adapter_elements.rb
+++ b/lib/rgeo/active_record/common_adapter_elements.rb
@@ -109,12 +109,12 @@ module RGeo
             statement_parts_ = [
               ('add_index ' + index_.table.inspect),
               index_.columns.inspect,
-              (':name => ' + index_.name.inspect),
+              ('name: ' + index_.name.inspect),
             ]
-            statement_parts_ << ':unique => true' if index_.unique
-            statement_parts_ << ':spatial => true' if index_.respond_to?(:spatial) && index_.spatial
+            statement_parts_ << 'unique: true' if index_.unique
+            statement_parts_ << 'spatial: true' if index_.respond_to?(:spatial) && index_.spatial
             index_lengths_ = (index_.lengths || []).compact
-            statement_parts_ << (':length => ' + ::Hash[*index_.columns.zip(index_.lengths).flatten].inspect) unless index_lengths_.empty?
+            statement_parts_ << ('length: ' + ::Hash[*index_.columns.zip(index_.lengths).flatten].inspect) unless index_lengths_.empty?
             '  ' + statement_parts_.join(', ')
           end
           stream_.puts add_index_statements_.sort.join("\n")


### PR DESCRIPTION
Use new style hash for schema dump to conform to rails commit
https://github.com/rails/rails/commit/b485b8a06626be3a1b8a2037092a9dda1b28e8a4 from Sep 7, 2012.
