### PR TITLE
Loosen activerecord dependency to allow 5.x

### DIFF
--- a/rgeo-activerecord.gemspec
+++ b/rgeo-activerecord.gemspec
@@ -16,7 +16,7 @@ require "./lib/rgeo/active_record/version"
   spec.required_ruby_version = ">= 1.9.3"
 
   spec.add_dependency "rgeo", "~> 0.3"
-  spec.add_dependency "activerecord", "~> 4.2"
+  spec.add_dependency "activerecord", ">= 4.2.0"
 
   spec.add_development_dependency "minitest", "~> 5.4"
   spec.add_development_dependency "rake", "~> 10.4"


### PR DESCRIPTION
Following @teeparham's lead on rgeo/activerecord-postgis-adapter#196