### PR TITLE
Remove unused struct, constant

### DIFF
--- a/lib/rgeo/active_record/common_adapter_elements.rb
+++ b/lib/rgeo/active_record/common_adapter_elements.rb
@@ -14,10 +14,6 @@ module RGeo
       spatial:             { type: "geometry" }.freeze,
     }.freeze
 
-    # Index definition struct with a spatial flag field.
-
-    SpatialIndexDefinition = Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :spatial)
-
     # Returns a feature type module given a string type.
 
     def self.geometric_type_from_name(name)

--- a/lib/rgeo/active_record/common_adapter_elements.rb
+++ b/lib/rgeo/active_record/common_adapter_elements.rb
@@ -1,21 +1,6 @@
 module RGeo
   module ActiveRecord
-    # Some default column constructors specifications for most spatial
-    # databases. Individual adapters may add to or override this list.
-    DEFAULT_SPATIAL_COLUMN_CONSTRUCTORS = {
-      geometry_collection: {}.freeze,
-      geometry:            {}.freeze,
-      line_string:         {}.freeze,
-      multi_line_string:   {}.freeze,
-      multi_point:         {}.freeze,
-      multi_polygon:       {}.freeze,
-      point:               {}.freeze,
-      polygon:             {}.freeze,
-      spatial:             { type: "geometry" }.freeze,
-    }.freeze
-
-    # Returns a feature type module given a string type.
-
+    # Return a feature type module given a string type.
     def self.geometric_type_from_name(name)
       case name.to_s
       when /^geometrycollection/i then Feature::GeometryCollection


### PR DESCRIPTION
These are only used by an old version of the activerecord-mysql2spatial-adapter adapter, which is tied to rgeo-activerecord version 1.0 and will need to re-write related code if it ever updates to this version.

Will require a major version bump.