### PR TITLE
Require rgeo 1.0

### DIFF
--- a/lib/rgeo/active_record/version.rb
+++ b/lib/rgeo/active_record/version.rb
@@ -1,5 +1,5 @@
 module RGeo
   module ActiveRecord
-    VERSION = "5.1.1".freeze
+    VERSION = "6.0.0".freeze
   end
 end

--- a/rgeo-activerecord.gemspec
+++ b/rgeo-activerecord.gemspec
@@ -14,12 +14,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.2.2"
 
-  spec.add_dependency "rgeo", "~> 0.3"
+  spec.add_dependency "rgeo", "~> 1.0"
   spec.add_dependency "activerecord", "~> 5.0"
 
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "mocha", "~> 1.1"
   spec.add_development_dependency "appraisal", "~> 2.1"
-  spec.add_development_dependency "rgeo-geojson", ">= 0.4.1"
+  spec.add_development_dependency "rgeo-geojson", "~> 1.0"
 end


### PR DESCRIPTION
If you are using proj4, you now need to include it explicitly in your Gemfile:

```ruby
gem "rgeo-proj4"
```