### PR TITLE
Add Cartesian::* classes to GeometryMixin

### DIFF
--- a/lib/rgeo/active_record/geometry_mixin.rb
+++ b/lib/rgeo/active_record/geometry_mixin.rb
@@ -82,6 +82,16 @@ module RGeo
       Geos::ZMMultiPolygonImpl,
       Geos::ZMPointImpl,
       Geos::ZMPolygonImpl,
+
+      Cartesian::PointImpl,
+      Cartesian::LineStringImpl,
+      Cartesian::LineImpl,
+      Cartesian::LinearRingImpl,
+      Cartesian::PolygonImpl,
+      Cartesian::GeometryCollectionImpl,
+      Cartesian::MultiPointImpl,
+      Cartesian::MultiLineStringImpl,
+      Cartesian::MultiPolygonImpl
     ].each { |klass| klass.include(GeometryMixin) }
 
     if RGeo::Geos.capi_supported?

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -14,6 +14,11 @@ class BasicTest < Minitest::Test
     end
   end
 
+  def test_as_json_simple_cartesian
+    setup_wkt
+    assert_equal "POINT (1.0 2.0)", simple_cartesian_factory.point(1, 2).as_json
+  end
+
   def test_json_generator_geojson
     RGeo::ActiveRecord::GeometryMixin.set_json_generator(:geojson)
     point = spherical_factory.point(1, 2)
@@ -65,6 +70,11 @@ class BasicTest < Minitest::Test
   # builds Geos::CAPI* features
   def cartesian_factory
     RGeo::Cartesian.preferred_factory
+  end
+
+  # builds Cartesian::* features
+  def simple_cartesian_factory
+    RGeo::Cartesian.simple_factory
   end
 
   # builds Geographic::Projected* features


### PR DESCRIPTION
Hello 👋 

while updating gems in one of our client projects I noticed that with the current version of RGeo (2.0.1) is that all of the RGeo::Cartesian features produce a `stack level too deep` error when serializing them to JSON (the project currently works with RGeo 0.4 😱 and I'd love to update). 
Since RGeo is heavily used in this project I had a quick look and it seems that unlike other feature classes those do not get the `GeometryMixin`. With that mixin it seems that the classes can be serialized again.
```
irb(main):007:0> RGeo::Cartesian.simple_factory.point(1,2).as_json
SystemStackError (stack level too deep)
```

I added the `Cartesian.*` classes in the list below. 
I'd be happy to change my contribution accoring to you r feedback (in case it makes sense) although I am not super familiar with the RGeo project, so bear with me 😄 .

Cheers,
Andi