### PR TITLE
`DepthFirst` visitor is no longer part of Rails 6.1

### DIFF
--- a/lib/rgeo/active_record/arel_spatial_queries.rb
+++ b/lib/rgeo/active_record/arel_spatial_queries.rb
@@ -89,7 +89,7 @@ module RGeo
     Arel::Visitors::DepthFirst.class_eval do
       alias :visit_RGeo_Feature_Instance :terminal
       alias :visit_RGeo_Cartesian_BoundingBox :terminal
-    end
+    end if defined?(Arel::Visitors::DepthFirst)
 
     Arel::Visitors::ToSql.class_eval do
       alias :visit_RGeo_Feature_Instance :visit_String


### PR DESCRIPTION
Ref https://github.com/rails/rails/pull/36492.