### PR TITLE
Fix alias issue

### DIFF
--- a/lib/rgeo/active_record/arel_spatial_queries.rb
+++ b/lib/rgeo/active_record/arel_spatial_queries.rb
@@ -32,7 +32,10 @@ module RGeo
           collector << ", " unless index == node.expressions.size - 1
         end
         collector << ")"
-        collector << " AS #{visit(node.alias, collector)}" if node.alias
+        if node.alias
+          collector << " AS "
+          visit node.alias, collector
+        end
         collector
       end
 


### PR DESCRIPTION
I have this code:
```
point = RGeo::Geographic.spherical_factory(srid: 4326).point(1.0, 1.0)

MyModel.where("ST_DWithin(my_models.lonlat, ST_GeographyFromText('SRID=4326;POINT(1.0 1.0)'), 10)").select(Arel.star, MyModel.arel_table[:lonlat].st_distance("SRID=4326;#{point}").as('distance')).to_sql
```

Rails 6.0.3.5
rgeo-activerecord 6.2.1
```
=> "SELECT *, ST_Distance(\"my_models\".\"lonlat\", ST_GeomFromEWKT('SRID=4326;POINT (1.0 1.0)')) AS distance FROM \"my_models\" WHERE (ST_DWithin(my_models.lonlat, ST_GeographyFromText('SRID=4326;POINT(1.0 1.0)'), 10))"
```

Rails 6.1.2.1
rgeo-activerecord 7.0.0
```
=> "SELECT *, ST_Distance(\"my_models\".\"lonlat\", ST_GeomFromEWKT('SRID=4326;POINT (1.0 1.0)'))distance AS #<Arel::Collectors::SubstituteBinds:0x00007ff9fd8f1390> FROM \"my_models\" WHERE (ST_DWithin(my_models.lonlat, ST_GeographyFromText('SRID=4326;POINT(1.0 1.0)'), 10))"
```

[Used the code from Rails repo](https://github.com/rails/rails/blame/5585c375d1ac4fb88a4e525a29b97f5f5b56b56a/activerecord/lib/arel/visitors/to_sql.rb#L369-L372) which seems to generate the right query.

I have no idea how to write a test for it or even if it's the right fix 😄 