### PR TITLE
Expand Tests, Fix Alias Bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      env:
+        BUNDLE_GEMFILE: ${{matrix.gemfile}}
       matrix:
         ruby: [2.7, 2.6, 2.5, jruby]
-        BUNDLE_GEMFILE:
+        gemfile:
           - gemfiles/ar50.gemfile
           - gemfiles/ar51.gemfile
           - gemfiles/ar52.gemfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,17 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{matrix.gemfile}}
     strategy:
-      env:
-        BUNDLE_GEMFILE: ${{matrix.gemfile}}
       matrix:
-        ruby: [2.7, 2.6, 2.5, jruby]
+        ruby:
+          - head
+          - "3.0"
+          - "2.7"
+          - "2.6"
+          - "2.5"
+          - jruby
         gemfile:
           - gemfiles/ar50.gemfile
           - gemfiles/ar51.gemfile

--- a/lib/rgeo/active_record/arel_spatial_queries.rb
+++ b/lib/rgeo/active_record/arel_spatial_queries.rb
@@ -32,7 +32,10 @@ module RGeo
           collector << ", " unless index == node.expressions.size - 1
         end
         collector << ")"
-        collector << " AS #{visit(node.alias, collector)}" if node.alias
+        if node.alias
+          collector << " AS "
+          visit node.alias, collector
+        end
         collector
       end
 

--- a/rgeo-activerecord.gemspec
+++ b/rgeo-activerecord.gemspec
@@ -1,4 +1,4 @@
-require "./lib/rgeo/active_record/version"
+require_relative "./lib/rgeo/active_record/version"
 
 Gem::Specification.new do |spec|
   spec.name = "rgeo-activerecord"
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["lib/**/*", "README.md", "History.md", "LICENSE.txt"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "activerecord", ">= 5.0"
   spec.add_dependency "rgeo", ">= 1.0.0"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ require "minitest/autorun"
 require "rgeo-activerecord"
 require "support/fake_record"
 
-Arel::Visitors::PostgreSQL.send(:include, RGeo::ActiveRecord::SpatialToSql)
+Arel::Visitors::ToSql.include RGeo::ActiveRecord::SpatialToSql
 Arel::Table.engine = FakeRecord::Base.new
 
 begin


### PR DESCRIPTION
Expands the Arel tests to include `alias` and `distinct`.

See #66 for more details about the malformed Arel sql.