### PR TITLE
Test Compatibility with RGeo 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - jruby
+          - "jruby-9.3.7.0"
           - "2.6"
         gemfile:
           - gemfiles/ar50.gemfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           - gemfiles/ar61.gemfile
           - gemfiles/ar70.gemfile
           - gemfiles/rgeo1.gemfile
+          - gemfile/rgeo3.gemfile
     steps:
       - name: Set Up Gems
         uses: actions/checkout@v2
@@ -41,7 +42,6 @@ jobs:
         ruby:
           - jruby
           - "2.6"
-          - "2.5"
         gemfile:
           - gemfiles/ar50.gemfile
           - gemfiles/ar51.gemfile
@@ -49,6 +49,7 @@ jobs:
           - gemfiles/ar60.gemfile
           - gemfiles/ar61.gemfile
           - gemfiles/rgeo1.gemfile
+          - gemfiles/rgeo3.gemfile
     steps:
       - name: Set Up Gems
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - gemfiles/ar61.gemfile
           - gemfiles/ar70.gemfile
           - gemfiles/rgeo1.gemfile
-          - gemfile/rgeo3.gemfile
+          - gemfiles/rgeo3.gemfile
     steps:
       - name: Set Up Gems
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
           - gemfiles/ar60.gemfile
           - gemfiles/ar61.gemfile
           - gemfiles/rgeo1.gemfile
-          - gemfiles/rgeo3.gemfile
     steps:
       - name: Set Up Gems
         uses: actions/checkout@v2

--- a/Appraisals
+++ b/Appraisals
@@ -19,7 +19,12 @@ appraise "ar61" do
 end
 
 appraise "ar70" do
-  gem "activerecord", "~> 7.0.0.rc1"
+  gem "activerecord", "~> 7.0.0"
+end
+
+appraise "rgeo3" do
+  gem "activerecord", "~> 7.0.0"
+  gem "rgeo", "~> 3.0.0.pre.rc.3"
 end
 
 appraise "rgeo1" do

--- a/Appraisals
+++ b/Appraisals
@@ -24,7 +24,7 @@ end
 
 appraise "rgeo3" do
   gem "activerecord", "~> 7.0.0"
-  gem "rgeo", "~> 3.0.0.pre.rc.3"
+  gem "rgeo", "~> 3.0.0"
 end
 
 appraise "rgeo1" do

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Here is an example setup:
 ```rb
 RGeo::ActiveRecord::SpatialFactoryStore.instance.tap do |config|
   # By default, use the GEOS implementation for spatial columns.
-  config.default = RGeo::Geos.factory_generator
+  config.default = RGeo::Geos.factory
 
   # But use a geographic implementation for point columns.
   config.register(RGeo::Geographic.spherical_factory(srid: 4326), geo_type: "point")

--- a/gemfiles/rgeo3.gemfile
+++ b/gemfiles/rgeo3.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 7.0.0"
-gem "rgeo", "~> 3.0.0.pre.rc.3"
+gem "rgeo", "~> 3.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rgeo3.gemfile
+++ b/gemfiles/rgeo3.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 7.0.0"
+gem "rgeo", "~> 3.0.0.pre.rc.3"
 
 gemspec path: "../"

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -91,7 +91,7 @@ class BasicTest < Minitest::Test
 
   def test_arel_visit_RGeo_ActiveRecord_SpatialNamedFunction_bbox
     visitor = arel_visitor
-    merc_factory = RGeo::Geos.factory(srid: 3857)
+    merc_factory = RGeo::Geos.factory(srid: 3857, wkt_generator: ruby_wkt_generator_opts)
     pt1 = merc_factory.point(1, 2)
     pt2 = merc_factory.point(2, 3)
     bbox = RGeo::Cartesian::BoundingBox.create_from_points(pt1, pt2)
@@ -135,9 +135,17 @@ class BasicTest < Minitest::Test
     RGeo::ActiveRecord::GeometryMixin.set_json_generator(nil)
   end
 
+  def ruby_wkt_generator_opts
+    {
+      convert_case: :upper
+    }
+  end
+
   # builds Geos::CAPI* features
   def geos_capi_factory
-    RGeo::Cartesian.preferred_factory
+    RGeo::Cartesian.preferred_factory(
+      wkt_generator: ruby_wkt_generator_opts
+    )
   end
 
   # builds Cartesian::* features
@@ -157,7 +165,7 @@ class BasicTest < Minitest::Test
 
   # builds Geos::FFI* features
   def ffi_factory
-    RGeo::Geos.factory(native_interface: :ffi)
+    RGeo::Geos.factory(native_interface: :ffi, wkt_generator: ruby_wkt_generator_opts)
   end
 
   # builds Geos::ZM* features


### PR DESCRIPTION
The only real note for this is that we need to force the test factories to use a ruby implemented WKT generatior.

One of the changes in RGeo3 is that we default to using the GEOS implemented WKT parser/generator in CAPI/FFI factories (https://github.com/rgeo/rgeo/pull/331), but this has slightly different outputs than the Ruby implemented generator, which has been the default in previous versions. This PR just forces the Ruby generator to be used so WKT output is consistent across all versions in the appraisal file.