### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/rgeo-activerecord.rb
+++ b/lib/rgeo-activerecord.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "rgeo/active_record"
+require_relative "rgeo/active_record"

--- a/lib/rgeo/active_record.rb
+++ b/lib/rgeo/active_record.rb
@@ -2,9 +2,10 @@
 
 require "rgeo"
 require "active_record"
-require "rgeo/active_record/version"
-require "rgeo/active_record/spatial_expressions"
-require "rgeo/active_record/spatial_factory_store"
-require "rgeo/active_record/arel_spatial_queries"
-require "rgeo/active_record/common_adapter_elements"
-require "rgeo/active_record/geometry_mixin"
+
+require_relative "active_record/version"
+require_relative "active_record/spatial_expressions"
+require_relative "active_record/spatial_factory_store"
+require_relative "active_record/arel_spatial_queries"
+require_relative "active_record/common_adapter_elements"
+require_relative "active_record/geometry_mixin"


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Refs:
- rgeo/rgeo#229
- rubocop/rubocop#8748