### PR TITLE
Add support for ActiveRecord 8.0 - 8.1 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,24 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
-          - "3.1"
-          - "jruby-9.4.8.0"
+          - "jruby-9.4.14.0"
         gemfile:
+          - gemfiles/ar81-beta.gemfile
+          - gemfiles/ar80.gemfile
           - gemfiles/ar72.gemfile
-          - gemfiles/ar71.gemfile
-          - gemfiles/ar70.gemfile
         channel: ['stable']
         include:
           - ruby: head
-            gemfile: gemfiles/ar71.gemfile
+            gemfile: gemfiles/ar80.gemfile
             channel: 'experimental'
           - ruby: head
             gemfile: gemfiles/ar72.gemfile
             channel: 'experimental'
           - ruby: jruby-head
-            gemfile: gemfiles/ar71.gemfile
+            gemfile: gemfiles/ar80.gemfile
             channel: 'experimental'
           - ruby: jruby-head
             gemfile: gemfiles/ar72.gemfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - "3.2"
           - "jruby-9.4.14.0"
         gemfile:
-          - gemfiles/ar81-beta.gemfile
+          - gemfiles/ar81_beta.gemfile
           - gemfiles/ar80.gemfile
           - gemfiles/ar72.gemfile
         channel: ['stable']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,13 @@ jobs:
           - gemfiles/ar80.gemfile
           - gemfiles/ar72.gemfile
         channel: ['stable']
+        exclude:
+          - ruby: "jruby-9.4.14.0"
+            gemfile: gemfiles/ar81_beta.gemfile
+            channel: 'stable'
+          - ruby: "jruby-9.4.14.0"
+            gemfile: gemfiles/ar80.gemfile
+            channel: 'stable'
         include:
           - ruby: head
             gemfile: gemfiles/ar80.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,11 @@
-appraise "ar70" do
-  gem "activerecord", "~> 7.0.0"
-end
-
-appraise "ar71" do
-  gem "activerecord", "~> 7.1.0"
-end
-
 appraise "ar72" do
   gem "activerecord", "~> 7.2.0"
+end
+
+appraise "ar80" do
+  gem "activerecord", "~> 8.0.0"
+end
+
+appraise "ar81-beta" do
+  gem "activerecord", "~> 8.1.0.beta"
 end

--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+### 9.0.0 / Unreleased
+
+* Drop support for legacy dependencies (t27duck)
+* Support ActiveRecord 8.0 and 8.1 beta (t27duck)
+
 ### 8.0.0 / 2024-09-11
 
 * Drop support for legacy dependencies (tagliala)

--- a/gemfiles/ar80.gemfile
+++ b/gemfiles/ar80.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.0.0"
+gem "activerecord", "~> 8.0.0"
 
 gemspec path: "../"

--- a/gemfiles/ar81_beta.gemfile
+++ b/gemfiles/ar81_beta.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.1.0"
+gem "activerecord", "~> 8.1.0.beta"
 
 gemspec path: "../"

--- a/lib/rgeo/active_record/arel_spatial_queries.rb
+++ b/lib/rgeo/active_record/arel_spatial_queries.rb
@@ -98,7 +98,12 @@ module RGeo
       include SpatialExpressions
 
       def initialize(name, expr, spatial_flags = [], aliaz = nil)
-        super(name, expr, aliaz)
+        if Arel::Nodes::NamedFunction.instance_method(:initialize).parameters.size == 2 # ActiveRecord 8.1+
+          super(name, expr)
+          @aliaz = aliaz
+        else # ActiveRecord 8.0 and earlier
+          super(name, expr, aliaz)
+        end
         @spatial_flags = spatial_flags
       end
 
@@ -108,6 +113,10 @@ module RGeo
 
       def spatial_argument?(index)
         @spatial_flags[index + 1]
+      end
+
+      def alias
+        @aliaz || (instance_variable_defined?(:@alias) ? @alias : nil)
       end
     end
 

--- a/rgeo-activerecord.gemspec
+++ b/rgeo-activerecord.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ffi-geos", "~> 1.2"
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "mocha", "~> 1.1"
-  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rgeo-geojson", ">= 1.0.0"
   spec.add_development_dependency "simplecov", ">= 0.20.0"
 end


### PR DESCRIPTION
- SpatialNamedFunction changed in ActiveRecord 8.1. Specifically the initialize method only takes two arguments now.
- Set up appraisals for ActiveRecord 8.0 and 8.1 beta. Removed unsupported ActiveRecord versions.
- Updated Github actions to run against supported Rubies and ActiveRecord versions.
- Updated gemspec to use rake 13 to remove a logger deprecation warning.